### PR TITLE
[MLIR][TORCH] Add pass to lower algorithmic ops

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -1307,3 +1307,21 @@ class StdBiasedModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: StdBiasedModule())
 def StdBiasedModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 3, 4))
+
+# ==============================================================================
+
+class BincountModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.int64, True),
+    ])
+    def forward(self, x):
+        return torch.bincount(x)
+
+@register_test_case(module_factory=lambda: BincountModule())
+def BincountModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(100, (10,)))

--- a/include/torch-mlir/Conversion/LowerAlgorithmicOps/LowerAlgorithmicOps.h
+++ b/include/torch-mlir/Conversion/LowerAlgorithmicOps/LowerAlgorithmicOps.h
@@ -1,0 +1,22 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TORCHMLIR_CONVERSION_LOWERALGORITHMICOPS_LOWERALGORITHMICOPS_H
+#define TORCHMLIR_CONVERSION_LOWERALGORITHMICOPS_LOWERALGORITHMICOPS_H
+
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+namespace torch {
+std::unique_ptr<OperationPass<FuncOp>> createConvertLowerAlgorithmicOpsPass();
+}
+} // namespace mlir
+
+#endif // TORCHMLIR_CONVERSION_LOWERALGORITHMICOPS_LOWERALGORITHMICOPS_H

--- a/include/torch-mlir/Conversion/Passes.td
+++ b/include/torch-mlir/Conversion/Passes.td
@@ -114,4 +114,15 @@ def ConvertTorchToTosa : Pass<"convert-torch-to-tosa", "FuncOp"> {
   let constructor = "mlir::torch::createConvertTorchToTosaPass()";
 }
 
+def ConvertLowerAlgorithmicOps : Pass<"convert-lower-algorithmic-ops", "FuncOp"> {
+  let summary = "Convert recognized Torch ops to Linalg ops";
+  let description = [{
+    Convert ATen ops to linalg ops.
+
+    This pass is similar to the TorchToLinalg pass; the difference is that this
+    pass also makes use of TMTensor Dialect, which the former one doesn't.
+  }];
+  let constructor = "mlir::torch::createConvertLowerAlgorithmicOpsPass()";
+}
+
 #endif // TORCHMLIR_CONVERSION_PASSES

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -2014,6 +2014,22 @@ def Torch_AtenNllLossBackwardOp : Torch_Op<"aten.nll_loss_backward", [
   let assemblyFormat = "$grad_output `,` $self `,` $target `,` $weight `,` $reduction `,` $ignore_index `,` $total_weight attr-dict `:` qualified(type($grad_output)) `,` qualified(type($self)) `,` qualified(type($target)) `,` qualified(type($weight)) `,` qualified(type($reduction)) `,` qualified(type($ignore_index)) `,` qualified(type($total_weight)) `->` qualified(type($result))";
 }
 
+def Torch_AtenBincountOp : Torch_Op<"aten.bincount", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::bincount : (Tensor, Tensor?, int) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchOptionalTensorType:$weights,
+    Torch_IntType:$minlength
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $weights `,` $minlength attr-dict `:` qualified(type($self)) `,` qualified(type($weights)) `,` qualified(type($minlength)) `->` qualified(type($result))";
+}
+
 def Torch_AtenConstantPadNdOp : Torch_Op<"aten.constant_pad_nd", [
     AllowsTypeRefinement,
     HasValueSemantics

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(TorchToLinalg)
 add_subdirectory(TorchToSCF)
 add_subdirectory(TorchToStd)
 add_subdirectory(TorchToTosa)
+add_subdirectory(LowerAlgorithmicOps)
 
 # TODO: Automate this with add_torch_mlir_conversion_library.
 #get_property(torch_mlir_conversion_libs GLOBAL PROPERTY TORCH_MLIR_CONVERSION_LIBS)
@@ -20,5 +21,6 @@ add_mlir_library(TorchMLIRConversionPasses
   TorchMLIRTorchToSCF
   TorchMLIRTorchToStd
   TorchMLIRTorchToTosa
+  TorchMLIRLowerAlgorithmicOps
   #${torch_mlir_conversion_libs}
 )

--- a/lib/Conversion/LowerAlgorithmicOps/CMakeLists.txt
+++ b/lib/Conversion/LowerAlgorithmicOps/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_mlir_conversion_library(TorchMLIRLowerAlgorithmicOps
+  LowerAlgorithmicOps.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/torch-mlir/Conversion/LowerAlgorithmicOps
+
+  DEPENDS
+  TorchMLIRConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRLinalg
+  MLIRMath
+  TorchMLIRTorchDialect
+  TorchMLIRTMTensorDialect
+)
+
+torch_mlir_target_includes(TorchMLIRLowerAlgorithmicOps)

--- a/lib/Conversion/LowerAlgorithmicOps/LowerAlgorithmicOps.cpp
+++ b/lib/Conversion/LowerAlgorithmicOps/LowerAlgorithmicOps.cpp
@@ -1,0 +1,235 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Conversion/LowerAlgorithmicOps/LowerAlgorithmicOps.h"
+
+#include "../PassDetail.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Utils/Utils.h"
+#include "mlir/Dialect/Traits.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorDialect.h"
+#include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOps.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/Torch/Utils/TorchUpstream.h"
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+using namespace torch;
+using namespace Torch;
+using namespace TorchConversion;
+using namespace torch_upstream; // For ScalarType and type
+using namespace TMTensor;
+
+// -----------------------------------------------------------------------------
+// Patterns (as this grows, it should be organized into multiple files)
+// -----------------------------------------------------------------------------
+// This is going to eventually be O(#aten ops), which is in the 100s.
+//
+// Most of these patterns consist of:
+// 1. Checking that the operand/result types and other static properties are
+//    good-enough to create a valid linalg op (such as operands being of
+//    ranks/dtypes acceptable to the linalg op).
+// 2. Creating dynamic error guards, usually checking a predicate on the
+//    compatibility of operand shapes.
+// 3. Creating init tensors for the computation op. Usually this involves
+//    reifying IR for a shape transfer function based on the operand shapes.
+// 4. Creating a named linalg op to replace the original op.
+//
+// TODO: Use linalg OpDSL to autogenerate at least 1)/2)/3) such
+// that these patterns become mostly mechanical associations of
+// "aten.foo -> linalg.foo".
+
+static LogicalResult verifyLinalgCompatibleTypes(Operation *op,
+                                                 PatternRewriter &rewriter) {
+  // Check the value tensor is ranked as expected by Linalg.
+  // TODO: Remove this check but use a separate verification pass to verify the
+  // invariants expected by later passes.
+  auto isValidLinalgType = [](Type type) {
+    auto tensor = type.dyn_cast<ValueTensorType>();
+    return !tensor ||
+           tensor.toBuiltinTensor().dyn_cast_or_null<RankedTensorType>();
+  };
+
+  bool valid = llvm::all_of(op->getOperandTypes(), isValidLinalgType) &&
+               llvm::all_of(op->getResultTypes(), isValidLinalgType);
+  if (!valid)
+    return rewriter.notifyMatchFailure(op, "type cannot be lowered to linalg");
+  return success();
+}
+
+// Creates a tensor with required `sizes` and `elemTy` and fills it with
+// initElem.
+static Value createInitTensor(OpBuilder &b, Location loc, ValueRange sizes,
+                              Type elemTy, Value initElem) {
+  Value initTensor = b.create<linalg::InitTensorOp>(loc, sizes, elemTy);
+  return b.create<linalg::FillOp>(loc, initElem, initTensor).getResult(0);
+}
+
+static Value castIntToIndex(OpBuilder &b, Location loc, Value v) {
+  assert(v.getType().isa<IntegerType>() && "must be called with integer type");
+  return b.create<arith::IndexCastOp>(loc, b.getIndexType(), v);
+}
+
+namespace {
+class ConvertAtenBincountOp : public OpConversionPattern<AtenBincountOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AtenBincountOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
+      return failure();
+    Location loc = op.getLoc();
+    Value input = adaptor.self();
+    Value minlength = adaptor.minlength();
+    RankedTensorType inputType = input.getType().cast<RankedTensorType>();
+
+    // Finding the maximum value in the input tensor.
+    Value initTensorMaxShape = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value constantZero = rewriter.create<arith::ConstantIntOp>(loc, 0, 64);
+    Value initTensorMax =
+        createInitTensor(rewriter, loc, {initTensorMaxShape},
+                         inputType.getElementType(), constantZero);
+
+    AffineExpr zeroDimExpr = mlir::getAffineDimExpr(0, op.getContext());
+    AffineExpr oneDimExpr = mlir::getAffineDimExpr(1, op.getContext());
+    auto indexingMaps = AffineMap::inferFromExprList({zeroDimExpr, oneDimExpr});
+    SmallVector<StringRef, 2> iteratorTypes{"reduction", "parallel"};
+
+    Value maxTensor =
+        rewriter
+            .create<linalg::GenericOp>(
+                loc, initTensorMax.getType(),
+                /*input*/ input,
+                /*output*/ initTensorMax,
+                /*indexingMaps=*/indexingMaps,
+                /*iteratorTypes=*/iteratorTypes,
+                [&](OpBuilder &b, Location loc, ValueRange args) {
+                  Value pred = b.create<arith::CmpIOp>(
+                      loc, arith::CmpIPredicate::ugt, args[0], args[1]);
+                  Value max =
+                      b.create<arith::SelectOp>(loc, pred, args[0], args[1]);
+                  b.create<linalg::YieldOp>(loc, max);
+                })
+            ->getResult(0);
+
+    Value maxIndex = castIntToIndex(rewriter, loc, constantZero);
+    Value maxInput =
+        rewriter.create<tensor::ExtractOp>(loc, maxTensor, maxIndex);
+
+    Value inputSize = rewriter.create<tensor::DimOp>(loc, input, 0);
+    Value constantOne = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
+    Value updates = createInitTensor(rewriter, loc, {inputSize},
+                                     constantOne.getType(), constantOne);
+
+    SmallVector<ReassociationIndices> reassociation(inputType.getRank());
+    reassociation[0].push_back(0);
+    reassociation[0].push_back(1);
+    auto resultType =
+        RankedTensorType::get({-1, 1}, inputType.getElementType());
+    auto expandedInput = rewriter.create<tensor::ExpandShapeOp>(
+        loc, resultType, input, reassociation);
+    resultType.dump();
+    expandedInput.dump();
+    resultType = RankedTensorType::get(expandedInput.getType().getShape(),
+                                       constantOne.getType());
+    Value truncatedInput =
+        rewriter.create<arith::TruncIOp>(loc, resultType, expandedInput);
+    Value bincountSize =
+        rewriter.create<arith::MaxUIOp>(loc, maxInput, minlength);
+    bincountSize = castIntToIndex(rewriter, loc, bincountSize);
+
+    Value bincount = createInitTensor(rewriter, loc, {bincountSize},
+                                      constantOne.getType(), constantOne);
+
+    auto scatterOp = rewriter.create<TMTensor::ScatterOp>(
+        loc, bincount.getType(), ValueRange{updates, truncatedInput}, bincount,
+        false);
+    scatterOp->dump();
+    Region &scatterOpRegion = scatterOp.region();
+    if (scatterOpRegion.empty())
+      llvm::errs() << "No region found\n";
+    // auto regionArgs = scatterOpRegion.getArguments();
+    // OpBuilder regionBuilder(scatterOpRegion);
+    // regionBuilder.create<arith::AddIOp>(scatterOp->getLoc(), regionArgs[0],
+    // regionArgs[1]);
+
+    // resultType = getTypeConverter()
+    //                       ->convertType(op->getResult(0).getType())
+    //                       .cast<RankedTensorType>();
+    // Value extendedResult =
+    //     rewriter.create<arith::ExtUIOp>(loc, resultType,
+    //     scatterOp->getResult(0));
+    // rewriter.replaceOpWithNewOp<tensor::CastOp>(op, resultType,
+    // extendedResult);
+    return success();
+  }
+};
+} // namespace
+
+// -----------------------------------------------------------------------------
+// The pass
+// -----------------------------------------------------------------------------
+
+namespace {
+class ConvertLowerAlgorithmicOps
+    : public ConvertLowerAlgorithmicOpsBase<ConvertLowerAlgorithmicOps> {
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect>();
+    registry.insert<StandardOpsDialect>();
+    registry.insert<tensor::TensorDialect>();
+    registry.insert<arith::ArithmeticDialect>();
+    registry.insert<TMTensorDialect>();
+    TorchConversion::getBackendTypeConversionDependentDialects(registry);
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ConversionTarget target(*context);
+    target.addLegalDialect<linalg::LinalgDialect, StandardOpsDialect,
+                           cf::ControlFlowDialect, math::MathDialect,
+                           tensor::TensorDialect, arith::ArithmeticDialect,
+                           TMTensorDialect>();
+
+    TypeConverter typeConverter;
+    typeConverter.addConversion([](Type type) { return type; });
+    TorchConversion::setupBackendTypeConversion(target, typeConverter);
+
+    RewritePatternSet patterns(context);
+    target.addIllegalOp<AtenBincountOp>();
+    patterns.add<ConvertAtenBincountOp>(typeConverter, context);
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<FuncOp>>
+mlir::torch::createConvertLowerAlgorithmicOpsPass() {
+  return std::make_unique<ConvertLowerAlgorithmicOps>();
+}

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -13,6 +13,7 @@
 #include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
 #include "torch-mlir/Conversion/TorchToStd/TorchToStd.h"
 #include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
+#include "torch-mlir/Conversion/LowerAlgorithmicOps/LowerAlgorithmicOps.h"
 
 //===----------------------------------------------------------------------===//
 // Pass registration

--- a/lib/Dialect/TorchConversion/Transforms/Passes.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/Passes.cpp
@@ -19,6 +19,7 @@
 #include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
 #include "torch-mlir/Conversion/TorchToStd/TorchToStd.h"
 #include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
+#include "torch-mlir/Conversion/LowerAlgorithmicOps/LowerAlgorithmicOps.h"
 #include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
 
 using namespace mlir;
@@ -59,6 +60,7 @@ void TorchConversion::createTorchBackendToLinalgOnTensorsBackendPipeline(
   // (e.g. dimensions which must be constant in a ranked programming model)
   // and those constants get somewhat obscured by TorchToStd.
   pm.addNestedPass<FuncOp>(createConvertTorchToLinalgPass());
+  pm.addNestedPass<FuncOp>(createConvertLowerAlgorithmicOpsPass());
   pm.addNestedPass<FuncOp>(createConvertTorchToStdPass());
   pm.addNestedPass<FuncOp>(createConvertTorchToSCFPass());
   pm.addNestedPass<FuncOp>(memref::createExpandOpsPass());

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -560,6 +560,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::var : (Tensor, bool) -> (Tensor)")
         emit("aten::nll_loss_forward : (Tensor, Tensor, Tensor?, int, int) -> (Tensor, Tensor)")
         emit("aten::nll_loss_backward : (Tensor, Tensor, Tensor, Tensor?, int, int, Tensor) -> (Tensor)")
+        emit ("aten::bincount : (Tensor, Tensor?, int) -> (Tensor)")
 
         # Misc tensor ops.
         emit("aten::constant_pad_nd : (Tensor, int[], Scalar) -> (Tensor)")


### PR DESCRIPTION
This pass is added to lower ops, which can not be lowered
via the TorchToLinalg pass, such as `embedding_dense_backward`
op. This pass also uses torch-mlir's TMTensor Dialect to lower the
complex ops.

Also add torch.bincount op lowering with the help of TMTensor dialect